### PR TITLE
Clean up exit behavior and error handling

### DIFF
--- a/flagconf.go
+++ b/flagconf.go
@@ -41,7 +41,6 @@ func ParseStrings(args []string, path string, config interface{}, allowNoConfigF
 	}
 
 	flagset := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	flagset.Usage = func() {}
 	// Create flags
 	if err := registerFlags(flagset, reflect.Indirect(v), "", ""); err != nil {
 		return err
@@ -55,12 +54,16 @@ func ParseStrings(args []string, path string, config interface{}, allowNoConfigF
 		}
 	}
 
+	// Prevent flagset.Parse from printing error and usage to stderr if parsing
+	// fails
+	flagset.Usage = func() {}
+	buf := &bytes.Buffer{}
+	flagset.SetOutput(buf)
+
 	// Override any settings with configured flags
 	if err = flagset.Parse(args[1:]); err != nil {
 		// In case flag parsing fails, return a custom error containing usage
 		// info if user wants to print it.
-		buf := &bytes.Buffer{}
-		flagset.SetOutput(buf)
 		flagset.PrintDefaults()
 		err = FlagError{Err: err, Usage: buf.String()}
 	}

--- a/flagconf.go
+++ b/flagconf.go
@@ -41,6 +41,7 @@ func ParseStrings(args []string, path string, config interface{}, allowNoConfigF
 	}
 
 	flagset := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	flagset.Usage = func() {}
 	// Create flags
 	if err := registerFlags(flagset, reflect.Indirect(v), "", ""); err != nil {
 		return err
@@ -189,9 +190,10 @@ func Parse(path string, config interface{}) error {
 // exits the program.
 func MustParse(path string, config interface{}) {
 	if err := ParseStrings(os.Args, path, config, false); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		if ferr, ok := err.(FlagError); ok {
 			fmt.Fprintln(os.Stderr, ferr.Usage)
+		} else {
+			fmt.Fprintln(os.Stderr, err)
 		}
 		os.Exit(2)
 	}

--- a/flagconf.go
+++ b/flagconf.go
@@ -64,8 +64,9 @@ func ParseStrings(args []string, path string, config interface{}, allowNoConfigF
 	if err = flagset.Parse(args[1:]); err != nil {
 		// In case flag parsing fails, return a custom error containing usage
 		// info if user wants to print it.
+		fmt.Fprintf(buf, "Usage of %s:\n", args[0])
 		flagset.PrintDefaults()
-		err = FlagError{Err: err, Usage: buf.String()}
+		err = FlagError{Err: err, Usage: strings.TrimSpace(buf.String())}
 	}
 	return err
 }

--- a/flagconf.go
+++ b/flagconf.go
@@ -81,6 +81,15 @@ func (e FlagError) Error() string {
 	return e.Err.Error()
 }
 
+// IsHelp checks whether err was caused by user requesting help output
+// (setting -h or --help flags).
+func IsHelp(err error) bool {
+	if err, ok := err.(FlagError); ok {
+		return err.Err == flag.ErrHelp
+	}
+	return err == flag.ErrHelp
+}
+
 /*
 Parse reads a TOML configuration file at path as well as user-supplied options
 from os.Args and sets matching options in config, which must be a non-nil pointer to a struct.

--- a/flagconf_test.go
+++ b/flagconf_test.go
@@ -1,6 +1,8 @@
 package flagconf
 
 import (
+	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -197,5 +199,17 @@ func TestGoodConfigs(t *testing.T) {
 			t.Log(test)
 			t.Error(err)
 		}
+	}
+}
+
+func TestIsHelp(t *testing.T) {
+	if !IsHelp(flag.ErrHelp) {
+		t.Fatal("IsHelp(flag.ErrHelp) != true")
+	}
+	if !IsHelp(FlagError{Err: flag.ErrHelp}) {
+		t.Fatal("IsHelp(FlagError{Err: flag.ErrHelp}) != true")
+	}
+	if IsHelp(errors.New("not help")) {
+		t.Fatal("IsHelp(not help) == true")
 	}
 }

--- a/flagconf_test.go
+++ b/flagconf_test.go
@@ -10,10 +10,11 @@ import (
 )
 
 type testCase struct {
-	config   interface{} // the (struct) initial configuration passed to ParseStrings
-	toml     string      // text of TOML file
-	args     []string    // user command-line arguments
-	expected interface{} // the expected state of the configuration after application of toml and flag parsing
+	config    interface{} // the (struct) initial configuration passed to ParseStrings
+	toml      string      // text of TOML file
+	args      []string    // user command-line arguments
+	expected  interface{} // the expected state of the configuration after application of toml and flag parsing
+	expectErr bool
 }
 
 func checkCase(test *testCase) error {
@@ -21,11 +22,11 @@ func checkCase(test *testCase) error {
 	if err != nil {
 		return err
 	}
+	name := tempfile.Name()
+	defer os.Remove(name)
 	if _, err := tempfile.WriteString(test.toml); err != nil {
 		return err
 	}
-	name := tempfile.Name()
-	defer func() { os.Remove(name) }()
 
 	if err := tempfile.Close(); err != nil {
 		return err
@@ -33,6 +34,12 @@ func checkCase(test *testCase) error {
 
 	args := append([]string{"test"}, test.args...)
 	err = ParseStrings(args, name, test.config, false)
+	if test.expectErr {
+		if err == nil {
+			return fmt.Errorf("parsing succeeded when it was expected to fail")
+		}
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("parsing failed when it was expected to succeed: %s", err)
 	}
@@ -160,11 +167,34 @@ f = [1, 2]`,
 		args:     []string{"-f=1,2"},
 		expected: &sliceCase{S: Strings{"a", "b"}, F: Ints{1, 2}},
 	},
+	{
+		config:    &simpleCase{},
+		args:      []string{"-f1=NaN"},
+		expectErr: true,
+	},
+	{
+		config:    &simpleCase{},
+		toml:      `f1 = "a"`,
+		expectErr: true,
+	},
+	{
+		config:    &simpleCase{},
+		toml:      `f1 = 1`,
+		args:      []string{"-f1=NaN"},
+		expectErr: true,
+	},
+	{
+		config:    &simpleCase{},
+		toml:      `f1 = "a"`,
+		args:      []string{"-f1=1"},
+		expectErr: true,
+	},
 }
 
 func TestGoodConfigs(t *testing.T) {
 	for _, test := range testCases {
 		if err := checkCase(test); err != nil {
+			t.Log(test)
 			t.Error(err)
 		}
 	}


### PR DESCRIPTION
Users can now choose between os.Exit on errors and handling errors themselves.
Returned error contains usage and an actual error from flag.Parse if that fails.

This is just conceptual approach, perhaps we can utilize FlagSet.Usage better.
