### PR TITLE
Don't create extra flag namespaces for embedded fields

### DIFF
--- a/flagconf.go
+++ b/flagconf.go
@@ -182,8 +182,8 @@ In TOML, a struct corresponds to a nested section; in flags the name will be dot
     // and this flag
     -s.n=3
 
-Embedded structs are handled similarly to encoding/json: fields of embedded
-struct are treated as if they were fields of embedding struct.
+Embedded structs are handled like in encoding/json: their exported fields are
+treated as if they were fields of the outer struct.
 
 Naming
 

--- a/flagconf.go
+++ b/flagconf.go
@@ -182,6 +182,9 @@ In TOML, a struct corresponds to a nested section; in flags the name will be dot
     // and this flag
     -s.n=3
 
+Embedded structs are handled similarly to encoding/json: fields of embedded
+struct are treated as if they were fields of embedding struct.
+
 Naming
 
 Matching names from TOML values to struct field names is much like encoding/json:
@@ -237,6 +240,10 @@ func registerFlags(flagset *flag.FlagSet, v reflect.Value, namespace, descriptio
 			}
 			desc := typ.Tag.Get("desc")
 			newNS := joinNS(namespace, name)
+			// For embedded fields don't create an extra nested namespace.
+			if v.Type().Field(i).Anonymous {
+				newNS = namespace
+			}
 			// Create uninitialized pointers to structs
 			if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
 				if field.IsNil() && field.IsValid() && field.CanSet() {

--- a/flagconf_test.go
+++ b/flagconf_test.go
@@ -59,11 +59,11 @@ type flagTagCase struct {
 	F1 int `flag:"f2"`
 }
 
-type embeddedCase struct {
+type nestedCase struct {
 	S1 *simpleCase
 }
 
-type nonPointerEmbeddedCase struct {
+type nonPointerNestedCase struct {
 	S1 simpleCase
 }
 
@@ -75,6 +75,18 @@ type ignoreCase struct {
 type sliceCase struct {
 	S Strings
 	F Ints
+}
+
+type embeddedCase struct {
+	EmbeddedInner
+}
+
+type embeddedCasePtr struct {
+	*EmbeddedInner
+}
+
+type EmbeddedInner struct {
+	F int
 }
 
 var testCases = []*testCase{
@@ -103,46 +115,46 @@ var testCases = []*testCase{
 		expected: &flagTagCase{F1: 4},
 	},
 	{
-		config: &embeddedCase{},
+		config: &nestedCase{},
 		toml: `[s1]
 f1 = 3`,
 		args:     nil,
-		expected: &embeddedCase{&simpleCase{F1: 3}},
+		expected: &nestedCase{&simpleCase{F1: 3}},
 	},
 	{
-		config: &embeddedCase{&simpleCase{}},
+		config: &nestedCase{&simpleCase{}},
 		toml: `[s1]
 f1 = 3`,
 		args:     nil,
-		expected: &embeddedCase{&simpleCase{F1: 3}},
+		expected: &nestedCase{&simpleCase{F1: 3}},
 	},
 	{
-		config: &embeddedCase{&simpleCase{}},
+		config: &nestedCase{&simpleCase{}},
 		toml: `[s1]
 f1 = 3`,
 		args:     []string{"-s1.f1=4"},
-		expected: &embeddedCase{&simpleCase{F1: 4}},
+		expected: &nestedCase{&simpleCase{F1: 4}},
 	},
 	{
-		config: &nonPointerEmbeddedCase{},
+		config: &nonPointerNestedCase{},
 		toml: `[s1]
 f1 = 3`,
 		args:     nil,
-		expected: &nonPointerEmbeddedCase{simpleCase{F1: 3}},
+		expected: &nonPointerNestedCase{simpleCase{F1: 3}},
 	},
 	{
-		config: &nonPointerEmbeddedCase{simpleCase{}},
+		config: &nonPointerNestedCase{simpleCase{}},
 		toml: `[s1]
 f1 = 3`,
 		args:     nil,
-		expected: &nonPointerEmbeddedCase{simpleCase{F1: 3}},
+		expected: &nonPointerNestedCase{simpleCase{F1: 3}},
 	},
 	{
-		config: &nonPointerEmbeddedCase{simpleCase{}},
+		config: &nonPointerNestedCase{simpleCase{}},
 		toml: `[s1]
 f1 = 3`,
 		args:     []string{"-s1.f1=4"},
-		expected: &nonPointerEmbeddedCase{simpleCase{F1: 4}},
+		expected: &nonPointerNestedCase{simpleCase{F1: 4}},
 	},
 	{
 		config:   &ignoreCase{},
@@ -190,6 +202,30 @@ f = [1, 2]`,
 		toml:      `f1 = "a"`,
 		args:      []string{"-f1=1"},
 		expectErr: true,
+	},
+	{
+		config:   &embeddedCase{},
+		toml:     "f = 3",
+		args:     nil,
+		expected: &embeddedCase{EmbeddedInner{F: 3}},
+	},
+	{
+		config:   &embeddedCase{},
+		toml:     "",
+		args:     []string{"-f=3"},
+		expected: &embeddedCase{EmbeddedInner{F: 3}},
+	},
+	{
+		config:   &embeddedCasePtr{},
+		toml:     "f = 3",
+		args:     nil,
+		expected: &embeddedCasePtr{&EmbeddedInner{F: 3}},
+	},
+	{
+		config:   &embeddedCasePtr{},
+		toml:     "",
+		args:     []string{"-f=3"},
+		expected: &embeddedCasePtr{&EmbeddedInner{F: 3}},
 	},
 }
 


### PR DESCRIPTION
Similar to how endoding/json handles embedded structs. This is also how
BurntSushi/toml handles them so it makes sense to have corresponding
flag names.

Sorry for the noise in tests, had to rename existing `embedded` to `nested`
to avoid confusion.
